### PR TITLE
add preact/hooks to webpack externals

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -74,7 +74,8 @@ module.exports = (env, { mode }) => {
       '@playkit-js/playkit-js-ui': 'root KalturaPlayer.ui',
       '@playkit-js/playkit-js': 'root KalturaPlayer.core',
       preact: 'root KalturaPlayer.ui.preact',
-      'preact-i18n': 'root KalturaPlayer.ui.preacti18n'
+      'preact-i18n': 'root KalturaPlayer.ui.preacti18n',
+      'preact/hooks': 'root KalturaPlayer.ui.preactHooks'
     },
     devServer: {
       static: {


### PR DESCRIPTION
### Description of the Changes

Add preact/hooks to webpack externals
Without this external, importing preact/hooks module can cause runtime errors


