### PR TITLE
fix(FEC-14000): css-loader create multiple styles tags

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 const webpack = require('webpack');
 const path = require('path');
 const packageData = require('./package.json');
+const CSS_MODULE_PREFIX = 'playkit';
 
 module.exports = (env, { mode }) => {
   return {
@@ -35,13 +36,19 @@ module.exports = (env, { mode }) => {
         {
           test: /\.scss/,
           use: [
-            'style-loader',
+            {
+              loader: 'style-loader',
+              options: {
+                attributes: {id: `${packageData.name}`},
+                injectType: "singletonStyleTag"
+              }
+            },
             {
               loader: 'css-loader',
               options: {
                 esModule: true,
                 modules: {
-                  localIdentName: '[local]',
+                  localIdentName: `${CSS_MODULE_PREFIX}-plx-[local]`,
                   namedExport: true
                 }
               }


### PR DESCRIPTION
### Description of the Changes

css-loader create multiple style tags

and missing identifier for the style element corresponds to the plugin

